### PR TITLE
Feat: Allow adding multiple authors per post

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -29,29 +29,57 @@
                 <h1 class="entry-title">{% if page.headline %}{{ page.headline }}{% else %}{{ page.title }}{% endif %}</h1>
                 {% endif %}
             </header>
-            <footer class="entry-meta">
-                {% if page.author %}
-                {% assign author = site.data.authors[page.author] %}{% else %}{% assign author = site.owner %}
-                {% endif %}
-                {% if author.gravatar %}
-                <img src="{{ author.gravatar | gravatar }}" class="bio-photo" alt="{{ author.name }} bio photo"></a>
-                {% else %}
-                {% if author.avatar contains 'http' %}
-                <img src="{{ author.avatar }}" class="bio-photo" alt="{{ author.name }} bio photo"></a>
-                {% else %}
-                <img src="{{ site.url }}/images/{{ author.avatar }}" class="bio-photo" alt="{{ author.name }} bio photo"></a>
-                {% endif %}
-                {% endif %}
-                {%if author.web %}
-                <span class="author vcard">By <span class="fn"><a target="_blank" href="{{ author.web }}">{{ author.name }}</a></span></span>
-                {% else %}
-                <span class="author vcard">By <span class="fn">{{ author.name }}</span></span>
-                {% endif %}
-                <span class="entry-date date published"><time datetime="{{ page.date | date_to_xmlschema }}"><i class="fa fa-calendar-o"></i> {{ page.date | date: "%B %d, %Y" }}</time></span>
-                {% if page.modified %}<span class="entry-date date modified"><time datetime="{{ page.modified }}"><i class="fa fa-pencil"></i> {{ page.modified | date: "%B %d, %Y" }}</time></span>{% endif %}
-                {% if site.owner.disqus-shortname and page.comments == true %}<span class="entry-comments"><i class="fa fa-comment-o"></i> <a href="#disqus_thread">Comment</a></span>{% endif %}
-                {% if page.share %}{% include social-share.html %}{% endif %}
-                {% if page.ads == true %}{% include ad-sidebar.html %}<!-- /.google-ads -->{% endif %}
+            <footer class="multi-authors-entry-meta">
+                <div>
+                    {% if page.author %}
+                    {% assign author = site.data.authors[page.author] %}{% else %}{% assign author = site.owner %}
+                    {% endif %}
+                    {% if author.gravatar %}
+                    <img src="{{ author.gravatar | gravatar }}" class="bio-photo" alt="{{ author.name }} bio photo"></a>
+                    {% else %}
+                    {% if author.avatar contains 'http' %}
+                    <img src="{{ author.avatar }}" class="bio-photo" alt="{{ author.name }} bio photo"></a>
+                    {% else %}
+                    <img src="{{ site.url }}/images/{{ author.avatar }}" class="bio-photo" alt="{{ author.name }} bio photo"></a>
+                    {% endif %}
+                    {% endif %}
+                    {%if author.web %}
+                    <span class="author vcard">By <span class="fn"><a target="_blank" href="{{ author.web }}">{{ author.name }}</a></span></span>
+                    {% else %}
+                    <span class="author vcard">By <span class="fn">{{ author.name }}</span></span>
+                    {% endif %}
+                    <span class="entry-date date published"><time datetime="{{ page.date | date_to_xmlschema }}"><i class="fa fa-calendar-o"></i> {{ page.date | date: "%B %d, %Y" }}</time></span>
+                    {% if page.modified %}<span class="entry-date date modified"><time datetime="{{ page.modified }}"><i class="fa fa-pencil"></i> {{ page.modified | date: "%B %d, %Y" }}</time></span>{% endif %}
+                    {% if site.owner.disqus-shortname and page.comments == true %}<span class="entry-comments"><i class="fa fa-comment-o"></i> <a href="#disqus_thread">Comment</a></span>{% endif %}
+                    {% if page.share %}{% include social-share.html %}{% endif %}
+                </div>
+
+                {% for author in page.coauthors %}
+                <div>
+                    {% if author %}
+                    {% assign coauthor = site.data.authors[author] %}{% else %}{% assign coauthor = site.owner %}
+                    {% endif %}
+                    {% if coauthor.gravatar %}
+                    <img src="{{ coauthor.gravatar | gravatar }}" class="bio-photo" alt="{{ coauthor.name }} bio photo"></a>
+                    {% else %}
+                    {% if coauthor.avatar contains 'http' %}
+                    <img src="{{ coauthor.avatar }}" class="bio-photo" alt="{{ coauthor.name }} bio photo"></a>
+                    {% else %}
+                    <img src="{{ site.url }}/images/{{ coauthor.avatar }}" class="bio-photo" alt="{{ coauthor.name }} bio photo"></a>
+                    {% endif %}
+                    {% endif %}
+                    {%if coauthor.web %}
+                    <span class="author vcard">By <span class="fn"><a target="_blank" href="{{ coauthor.web }}">{{ coauthor.name }}</a></span></span>
+                    {% else %}
+                    <span class="author vcard">By <span class="fn">{{ coauthor.name }}</span></span>
+                    {% endif %}
+                    <span class="entry-date date published"><time datetime="{{ page.date | date_to_xmlschema }}"><i class="fa fa-calendar-o"></i> {{ page.date | date: "%B %d, %Y" }}</time></span>
+                    {% if page.modified %}<span class="entry-date date modified"><time datetime="{{ page.modified }}"><i class="fa fa-pencil"></i> {{ page.modified | date: "%B %d, %Y" }}</time></span>{% endif %}
+                    {% if site.owner.disqus-shortname and page.comments == true %}<span class="entry-comments"><i class="fa fa-comment-o"></i> <a href="#disqus_thread">Comment</a></span>{% endif %}
+                    {% if page.share %}{% include social-share.html %}{% endif %}
+                    {% if page.ads == true %}{% include ad-sidebar.html %}<!-- /.google-ads -->{% endif %}
+                </div>
+                {% endfor %}
             </footer>
             <div class="entry-content">
                 {{ content }}

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -267,6 +267,30 @@ span + .entry-title {
 		}
 	}
 }
+.multi-authors-entry-meta {
+	@include span-columns(12);
+	text-transform: uppercase;
+	@include font-size(14);
+	a { 
+		color: $text-color; 
+	}
+	@include media($large) {
+		@include span-columns(2.5);
+	}
+  & > div {
+    margin-bottom: 10px;
+  }
+	& > div > span {
+		padding: 0 20px 10px 0;
+		display: inline-block;
+		@include media($large) {
+			display: block;
+			padding: 8px 0;
+			border-bottom: 1px solid lighten($black,80);
+			border-bottom: 1px solid rgba($black,.10);
+		}
+	}
+}
 .bio-photo {
 	display: none;
 	@include media($large) {


### PR DESCRIPTION
This pull requests allow each post to have multiple authors, and have their avatar displayed in the post.

Each post under the `_posts` directory can add an optional yaml field named `coauthors`, which is a list of authors defined in the `_data/authors.yml` file. The post will then automatically render the additional authors. The `author` field is still needed for the first author.